### PR TITLE
Add millisecond precision to epoch timestamps

### DIFF
--- a/src/duktape/duk_config.h
+++ b/src/duktape/duk_config.h
@@ -851,6 +851,7 @@
  * one second resolution.
  */
 #define DUK_USE_DATE_NOW_TIME
+#define TICKS_PER_SEC 2000
 
 /* The most portable way to figure out local time offset is gmtime(),
  * but it's not thread safe so use with caution.

--- a/src/duktape/duktape.c
+++ b/src/duktape/duktape.c
@@ -33590,12 +33590,11 @@ DUK_INTERNAL duk_double_t duk_bi_date_get_now_gettimeofday(void) {
 #endif  /* DUK_USE_DATE_NOW_GETTIMEOFDAY */
 
 #if defined(DUK_USE_DATE_NOW_TIME)
-
-static clock_t current_time = 0;
-static time_t last_time = 0;
+static clock_t start_ms = 0;
+static time_t prev_minute = 0;
 
 DUK_INTERNAL duk_double_t duk_bi_date_get_now_time(void) {
-	clock_t ms;
+	clock_t ms = 0;
 	time_t t = time(NULL);
 
 	if (t == (time_t) -1) {
@@ -33603,12 +33602,12 @@ DUK_INTERNAL duk_double_t duk_bi_date_get_now_time(void) {
 		return 0.0;
 	}
 
-	if (last_time == t) {
-		ms = (((clock() - current_time)/2) - 1)%CLOCKS_PER_SEC;
+	if (prev_minute == t) {
+		ms = (clock() - start_ms)/(TICKS_PER_SEC/1000) - 1;
 	}
 	else {
-		last_time = t;
-		current_time = clock();
+		prev_minute = t;
+		start_ms = clock();
 	}
 
 	return ((duk_double_t) t) * 1000.0 + ms;


### PR DESCRIPTION
`Date.now()`, `performance.now()` and `new Date().getTime()` now return a proper timestamp in milliseconds. I edited the fallback function provided by Duktape and kept referencing an external clock for the milliseconds themselves. Not sure if it's the best approach so let me know what you think.

Closes #3 

To verify it's working:

```javascript
Display.setVSync(true);
Font.fmLoad()

while(1){
    Display.clear(Color.new(0,0,0)) ;
    Font.fmPrint(10, 10, .5, "Milliseconds elapsed since the epoch: " + Date.now(), Color.new(255, 255, 255));
    Display.flip();
}
```