### PR TITLE
initialize memory card RPC server

### DIFF
--- a/src/module_system.c
+++ b/src/module_system.c
@@ -212,6 +212,7 @@ int load_default_module(int id) {
     			ID = SifExecModuleBuffer(&mcserv_irx, size_mcserv_irx, 0, NULL, &ret);
 				REPORT("MCSERV");
 				mc_started = LOAD_SUCCESS();
+				if (mc_started) mcInit(MC_TYPE_XMC); //to avoid hang on RPC for a module that did not remain resident
 			}
 			break;
 


### PR DESCRIPTION
RPC server bind was missing, resulting in abnormal values all over the place