### PR TITLE
fix: Socket Module

### DIFF
--- a/src/js_api/ath_socket.c
+++ b/src/js_api/ath_socket.c
@@ -116,7 +116,7 @@ static JSValue athena_socket_recv(JSContext *ctx, JSValue this_val, int argc, JS
 
     void* buf = js_mallocz(ctx, len);
 
-    recv(s->id, buf, len, MSG_PEEK);
+    recv(s->id, buf, len, MSG_DONTWAIT);
     return JS_NewStringLen(ctx, buf, len);
 }
 

--- a/src/js_api/ath_socket.c
+++ b/src/js_api/ath_socket.c
@@ -119,7 +119,7 @@ static JSValue athena_socket_listen(JSContext *ctx, JSValue this_val, int argc, 
 }
 
 static JSValue athena_socket_recv(JSContext *ctx, JSValue this_val, int argc, JSValueConst *argv) {
-	if (argc != 1) return JS_ThrowSyntaxError(ctx, "Socket.recv takes a single argument");
+    if (argc != 1) return JS_ThrowSyntaxError(ctx, "Socket.recv takes a single argument");
 
     JSSocketData* s = JS_GetOpaque2(ctx, this_val, js_socket_class_id);
 
@@ -128,11 +128,18 @@ static JSValue athena_socket_recv(JSContext *ctx, JSValue this_val, int argc, JS
 
     void* buf = js_mallocz(ctx, len);
 
-    recv(s->id, buf, len, MSG_DONTWAIT);
+    int received = recv(s->id, buf, len, MSG_DONTWAIT);
 
-	js_free(ctx, buf);
-	
-    return JS_NewStringLen(ctx, buf, len);
+    JSValue result;
+    if (received > 0) {
+        result = JS_NewStringLen(ctx, buf, received);
+    } else {
+        result = JS_NewString(ctx, "");
+    }
+
+    js_free(ctx, buf);
+
+    return result;
 }
 
 static JSClassDef js_socket_class = {

--- a/src/js_api/ath_socket.c
+++ b/src/js_api/ath_socket.c
@@ -47,13 +47,18 @@ static JSValue athena_socket_connect(JSContext *ctx, JSValue this_val, int argc,
 
     struct sockaddr_in addr;
     int32_t sin_port;
+	const char* ip_str;
 
     JSSocketData* s = JS_GetOpaque2(ctx, this_val, js_socket_class_id);
+
+	ip_str = JS_ToCString(ctx, argv[0]);
 
     memset(&addr, 0, sizeof(addr));
     addr.sin_len = sizeof(addr);
     addr.sin_family = s->sin_family;
-    addr.sin_addr.s_addr = ipaddr_addr(JS_ToCString(ctx, argv[0]));
+    addr.sin_addr.s_addr = ipaddr_addr(ip_str);
+
+	JS_FreeCString(ctx, ip_str);
 
     JS_ToInt32(ctx, &sin_port, argv[1]);
     addr.sin_port = htons(sin_port);
@@ -68,15 +73,20 @@ static JSValue athena_socket_bind(JSContext *ctx, JSValue this_val, int argc, JS
 
     struct sockaddr_in addr;
     int32_t sin_port;
+	const char* ip_str;
 
     JSSocketData* s = JS_GetOpaque2(ctx, this_val, js_socket_class_id);
+	ip_str = JS_ToCString(ctx, argv[0]);
 
     memset(&addr, 0, sizeof(addr));
     addr.sin_len = sizeof(addr);
     addr.sin_family = s->sin_family;
-    addr.sin_addr.s_addr = ipaddr_addr(JS_ToCString(ctx, argv[0]));
+    addr.sin_addr.s_addr = ipaddr_addr(ip_str);
+	
     JS_ToInt32(ctx, &sin_port, argv[1]);
     addr.sin_port = htons(sin_port);
+
+	JS_FreeCString(ctx, ip_str);
 
     int ret = bind(s->id, (struct sockaddr*)&addr, sizeof(addr));
 
@@ -93,6 +103,8 @@ static JSValue athena_socket_send(JSContext *ctx, JSValue this_val, int argc, JS
 
     int ret = send(s->id, buf, len, MSG_DONTWAIT);
 
+	JS_FreeCString(ctx, buf);
+	
     return JS_NewInt32(ctx, ret);
 }
 
@@ -117,6 +129,9 @@ static JSValue athena_socket_recv(JSContext *ctx, JSValue this_val, int argc, JS
     void* buf = js_mallocz(ctx, len);
 
     recv(s->id, buf, len, MSG_DONTWAIT);
+
+	js_free(ctx, buf);
+	
     return JS_NewStringLen(ctx, buf, len);
 }
 

--- a/src/js_api/ath_websocket.c
+++ b/src/js_api/ath_websocket.c
@@ -112,6 +112,17 @@ static JSValue athena_ws_send(JSContext *ctx, JSValue this_val, int argc, JSValu
     return JS_NewUint32(ctx, size);
 }
 
+static JSValue athena_ws_close(JSContext *ctx, JSValue this_val, int argc, JSValueConst *argv)
+{
+    ath_ws_ctx_t *ws = (ath_ws_ctx_t*)JS_GetOpaque2(ctx, this_val, js_ws_class_id);
+    if (!ws)
+        return JS_UNDEFINED;
+
+    ath_ws_close(ws);
+    JS_SetOpaque(this_val, NULL);
+    return JS_UNDEFINED;
+}
+
 static JSClassDef js_ws_class = {
     "WebSocket",
     .finalizer = athena_ws_dtor,
@@ -121,6 +132,7 @@ static const JSCFunctionListEntry athena_ws_funcs[] = {
     JS_CGETSET_MAGIC_DEF("verifyTLS", athena_ws_get, athena_ws_set, 0),
     JS_CFUNC_DEF("send", 1, athena_ws_send),
     JS_CFUNC_DEF("recv", 0, athena_ws_recv),
+	JS_CFUNC_DEF("close", 0, athena_ws_close),
 };
 
 static int ws_init(JSContext *ctx, JSModuleDef *m) {


### PR DESCRIPTION
This is a short fix in the Athena's Socket module.

I fixed the recv function by switching MSG_PEEK to MSG_DONTWAIT to turn that function into a NON-BLOCKING function, because the game was crashing when the recv function didn't receive anything.

I also fixed some memory leak problems with JS_ToCString, calling JS_FreeCString for every message received.