### PR TITLE
fix(Image): draw() for stateless drawing with temporary clip/scale params

### DIFF
--- a/src/athena/image.c
+++ b/src/athena/image.c
@@ -106,18 +106,25 @@ bool athena_image_is_loaded(const AthenaImage *image) {
     return image && image->loaded;
 }
 
-void athena_image_draw(AthenaImage *image, float x, float y) {
+void athena_image_draw(
+                        AthenaImage *image, 
+                        float x, float y,
+                        float width, float height,
+                        float startx, float starty,
+                        float endx, float endy,
+                        float angle, uint32_t color
+) {
     if (!image || !image->tex)
         return;
 
-    if (image->angle != 0.0f) {
-        draw_image_rotate(image->tex, x, y, image->width, image->height,
-                          image->startx, image->starty, image->endx, image->endy,
-                          image->angle, image->color);
+    if (angle != 0.0f) {
+        draw_image_rotate(image->tex, x, y, width, height,
+                          startx, starty, endx, endy,
+                          angle, color);
     } else {
-        draw_image(image->tex, x, y, image->width, image->height,
-                   image->startx, image->starty, image->endx, image->endy,
-                   image->color);
+        draw_image(image->tex, x, y, width, height,
+                   startx, starty, endx, endy,
+                   color);
     }
 }
 

--- a/src/include/athena/image.h
+++ b/src/include/athena/image.h
@@ -29,7 +29,14 @@ void athena_image_destroy(AthenaImage *image);
 void athena_image_free(AthenaImage *image);
 
 bool athena_image_is_loaded(const AthenaImage *image);
-void athena_image_draw(AthenaImage *image, float x, float y);
+void athena_image_draw(
+                        AthenaImage *image, 
+                        float x, float y,
+                        float width, float height,
+                        float startx, float starty,
+                        float endx, float endy,
+                        float angle, uint32_t color
+);
 bool athena_image_lock(AthenaImage *image);
 bool athena_image_unlock(AthenaImage *image);
 bool athena_image_locked(const AthenaImage *image);

--- a/src/js_api/ath_image.c
+++ b/src/js_api/ath_image.c
@@ -100,7 +100,7 @@ static inline int get_optional_uint32(JSContext *ctx, JSValue obj, const char *p
     return 0;
 }
 
-static JSValue athena_image_draw(JSContext *ctx, JSValue this_val, int argc, JSValueConst *argv)
+static JSValue js_image_draw(JSContext *ctx, JSValue this_val, int argc, JSValueConst *argv)
 {
     AthenaImage *image = JS_GetOpaque2(ctx, this_val, js_image_class_id);
     
@@ -113,7 +113,7 @@ static JSValue athena_image_draw(JSContext *ctx, JSValue this_val, int argc, JSV
     }
     
     if (argc < 2) {
-        return JS_ThrowTypeError(ctx, "drawEx requires at least (x, y)");
+        return JS_ThrowTypeError(ctx, "draw requires at least (x, y)");
     }
     
     float x, y;

--- a/src/js_api/ath_image.c
+++ b/src/js_api/ath_image.c
@@ -143,7 +143,8 @@ static JSValue js_image_draw(JSContext *ctx, JSValue this_val, int argc, JSValue
             return JS_EXCEPTION;
         }
     }
-    athena_image_draw(image, x, y);
+
+    athena_image_draw(image, x, y, width, height, startx, starty, endx, endy, angle, color);
     return JS_UNDEFINED;
 }
 

--- a/src/js_api/ath_image.c
+++ b/src/js_api/ath_image.c
@@ -70,11 +70,79 @@ static JSValue js_image_free(JSContext *ctx, JSValue this_val, int argc, JSValue
     return JS_UNDEFINED;
 }
 
-static JSValue js_image_draw(JSContext *ctx, JSValue this_val, int argc, JSValueConst *argv) {
-    float x, y;
+static inline int get_optional_float(JSContext *ctx, JSValue obj, const char *prop, float *out)
+{
+    JSValue v = JS_GetPropertyStr(ctx, obj, prop);
+    if (JS_IsUndefined(v) || JS_IsNull(v)) {
+        JS_FreeValue(ctx, v);
+        return 0;
+    }
+    if (JS_ToFloat32(ctx, out, v)) {
+        JS_FreeValue(ctx, v);
+        return -1;
+    }
+    JS_FreeValue(ctx, v);
+    return 0;
+}
+
+static inline int get_optional_uint32(JSContext *ctx, JSValue obj, const char *prop, uint32_t *out)
+{
+    JSValue v = JS_GetPropertyStr(ctx, obj, prop);
+    if (JS_IsUndefined(v) || JS_IsNull(v)) {
+        JS_FreeValue(ctx, v);
+        return 0;
+    }
+    if (JS_ToUint32(ctx, out, v)) {
+        JS_FreeValue(ctx, v);
+        return -1;
+    }
+    JS_FreeValue(ctx, v);
+    return 0;
+}
+
+static JSValue athena_image_draw(JSContext *ctx, JSValue this_val, int argc, JSValueConst *argv)
+{
     AthenaImage *image = JS_GetOpaque2(ctx, this_val, js_image_class_id);
-    JS_ToFloat32(ctx, &x, argv[0]);
-    JS_ToFloat32(ctx, &y, argv[1]);
+    
+    if (!image) {
+        return JS_ThrowTypeError(ctx, "invalid Image object");
+    }
+    
+    if (!image->loaded) {
+        return JS_ThrowInternalError(ctx, "image not loaded");
+    }
+    
+    if (argc < 2) {
+        return JS_ThrowTypeError(ctx, "drawEx requires at least (x, y)");
+    }
+    
+    float x, y;
+    if (JS_ToFloat32(ctx, &x, argv[0]) || JS_ToFloat32(ctx, &y, argv[1])) {
+        return JS_EXCEPTION;
+    }
+    
+    float width  = image->width;
+    float height = image->height;
+    float startx = image->startx;
+    float starty = image->starty;
+    float endx   = image->endx;
+    float endy   = image->endy;
+    float angle  = image->angle;
+    uint32_t color = image->color;
+    
+    if (argc > 2 && JS_IsObject(argv[2]) && !JS_IsArray(ctx, argv[2])) {
+        if (get_optional_float(ctx, argv[2], "width",  &width)  < 0 ||
+            get_optional_float(ctx, argv[2], "height", &height) < 0 ||
+            get_optional_float(ctx, argv[2], "startx", &startx) < 0 ||
+            get_optional_float(ctx, argv[2], "starty", &starty) < 0 ||
+            get_optional_float(ctx, argv[2], "endx",   &endx)   < 0 ||
+            get_optional_float(ctx, argv[2], "endy",   &endy)   < 0 ||
+            get_optional_float(ctx, argv[2], "angle",  &angle)  < 0 ||
+            get_optional_uint32(ctx, argv[2], "color", &color)  < 0)
+        {
+            return JS_EXCEPTION;
+        }
+    }
     athena_image_draw(image, x, y);
     return JS_UNDEFINED;
 }


### PR DESCRIPTION
Nowadays, the object `Image` in AthenaENV is *stateful*: props like `width`, `height`, `startx`, `endx`, `endy`, `angle` e `color` are part of the internal state from instace and are used directly by `draw()`. 

When multiple entities share the same texture via an Assets Cache Manager, any change in those props to draw a specific sprite affects all other instances. 

So, I propose a solution: add a new parameter to the method ' draw (x, y, options) '. It works like the draw method, but the user can add one more argument, which is an object that can receive any image property. These values are just used locally.

The user can write something like the code below:

```js
img.draw(x, y, {
    width:  82,
    height: 164,
    startx: 0,
    starty: 0,
    endx:   82,
    endy:   164
});
```